### PR TITLE
Add package type verification script, update exports, and enhance workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Build package
         run: npm run build --if-present
 
+      - name: Verify packaged type declarations
+        run: node ./scripts/verify-package-types.mjs
+
       - name: Publish to npm with trusted publishing
         run: npm publish --access public
 

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -51,6 +51,16 @@ jobs:
       - run: npm run lint-check
       - run: npm run format-check
 
+  package-types:
+    name: Package Types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-node
+      - run: npm ci
+      - name: Verify packaged type declarations
+        run: npm run test:package-types
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/vue/CONTRIBUTE.md
+++ b/vue/CONTRIBUTE.md
@@ -80,6 +80,7 @@ To work with `pnpm` or `yarn`, delete `package-lock.json` and run the equivalent
 | `npm run test:unit` | Execute Vitest unit tests once |
 | `npm run test:unit:watch` | Run unit tests in watch mode |
 | `npm run test:e2e` | Build the demo and run Playwright end-to-end tests |
+| `npm run test:package-types` | Build the package, pack it, and verify published subpath type declarations |
 
 ## Quality Gates
 
@@ -89,7 +90,8 @@ Before opening a pull request make sure:
 2. `npm run format-check` passes (or run `npm run format`).
 3. `npm run test:unit` succeeds.
 4. `npm run test:e2e` passes when your changes touch interactive flows or routing.
-5. `npm run build` finishes cleanly.
+5. `npm run test:package-types` passes when you change exports, packaging, or declaration generation.
+6. `npm run build` finishes cleanly.
 
 Document deviations from these gates in the pull request summary and explain the follow-up plan.
 

--- a/vue/README.md
+++ b/vue/README.md
@@ -154,6 +154,7 @@ From the `vue/` directory:
 | `npm run build-storybook` | Build the static Storybook site |
 | `npm run lint` / `npm run lint-check` | Auto-fix or check ESLint rules |
 | `npm run format` / `npm run format-check` | Run Prettier in write/check mode |
+| `npm run test:package-types` | Build the package, pack it, and verify published type declarations |
 
 The project supports Node.js `^20.19.0 || ^22.13.0 || >=24.0.0`. Use the included `.node-version` or `.nvmrc` to align with CI; the repository currently pins `24.9.0`.
 
@@ -162,6 +163,7 @@ The project supports Node.js `^20.19.0 || ^22.13.0 || >=24.0.0`. Use the include
 - Unit tests: `npm run test:unit`
 - Unit tests in watch mode: `npm run test:unit:watch`
 - End-to-end tests (Playwright against the demo app): `npm run test:e2e`
+- Packaged declaration smoke test: `npm run test:package-types`
 
 Aim for meaningful coverage when adding or changing components. Update or create MDX docs and Storybook stories alongside code changes.
 

--- a/vue/package.json
+++ b/vue/package.json
@@ -30,18 +30,22 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/lib.d.ts",
       "import": "./dist/lib.js",
       "require": "./dist/lib.cjs"
     },
     "./router": {
+      "types": "./dist/router.d.ts",
       "import": "./dist/router.js",
       "require": "./dist/router.cjs"
     },
     "./containers": {
+      "types": "./dist/containers.d.ts",
       "import": "./dist/containers.js",
       "require": "./dist/containers.cjs"
     },
     "./network": {
+      "types": "./dist/network.d.ts",
       "import": "./dist/network.js",
       "require": "./dist/network.cjs"
     },
@@ -67,7 +71,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "openapi-codegen": "npx @hey-api/openapi-ts --input ./src/demo/openapi.yaml --output ./src/demo/openapi --client @hey-api/client-axios",
-    "knip": "knip"
+    "knip": "knip",
+    "test:package-types": "npm run build-only && node ./scripts/verify-package-types.mjs"
   },
   "dependencies": {
     "@primeuix/themes": "^2.0.3",

--- a/vue/scripts/verify-package-types.mjs
+++ b/vue/scripts/verify-package-types.mjs
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = dirname(fileURLToPath(import.meta.url))
+const workspaceRoot = dirname(repoRoot)
+const tempBaseDir = join(workspaceRoot, 'node_modules', '.tmp')
+
+mkdirSync(tempBaseDir, { recursive: true })
+
+const smokeTestRoot = mkdtempSync(join(tempBaseDir, 'wefa-package-types-'))
+let tarballPath
+
+try {
+  const packOutput = execFileSync('npm', ['pack', '--json'], {
+    cwd: workspaceRoot,
+    encoding: 'utf8',
+  })
+  const [{ filename }] = JSON.parse(packOutput)
+  tarballPath = join(workspaceRoot, filename)
+
+  const packagedNetworkDts = execFileSync('tar', ['-xOf', tarballPath, 'package/dist/network.d.ts'], {
+    cwd: workspaceRoot,
+    encoding: 'utf8',
+  })
+
+  for (const expectedExport of [
+    "export { default as axiosInstance } from './src/network/axios';",
+    "export { default as apiClient } from './src/network/apiClient';",
+    "export { default as typedApiClient } from './src/network/typedApiClient';",
+  ]) {
+    if (!packagedNetworkDts.includes(expectedExport)) {
+      throw new Error(`Missing network declaration export: ${expectedExport}`)
+    }
+  }
+
+  const packagedTypedApiClientDts = execFileSync(
+    'tar',
+    ['-xOf', tarballPath, 'package/dist/src/network/typedApiClient.d.ts'],
+    {
+      cwd: workspaceRoot,
+      encoding: 'utf8',
+    },
+  )
+
+  for (const expectedMember of ['setupOpenApiClient', 'query', 'mutation']) {
+    if (!packagedTypedApiClientDts.includes(expectedMember)) {
+      throw new Error(`Missing typedApiClient declaration member: ${expectedMember}`)
+    }
+  }
+
+  const packagedScopeDir = join(smokeTestRoot, 'node_modules', '@nside')
+  mkdirSync(packagedScopeDir, { recursive: true })
+  execFileSync('tar', ['-xzf', tarballPath, '-C', packagedScopeDir], { cwd: workspaceRoot })
+  renameSync(join(packagedScopeDir, 'package'), join(packagedScopeDir, 'wefa'))
+
+  writeFileSync(
+    join(smokeTestRoot, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          target: 'ES2022',
+          strict: true,
+          skipLibCheck: false,
+          noEmit: true,
+        },
+        include: ['./index.ts'],
+      },
+      null,
+      2,
+    ),
+  )
+
+  writeFileSync(
+    join(smokeTestRoot, 'index.ts'),
+    [
+      "import { typedApiClient, apiClient, axiosInstance } from '@nside/wefa/network'",
+      '',
+      'typedApiClient.setupOpenApiClient({ setConfig() {} })',
+      'void typedApiClient.query',
+      'void typedApiClient.mutation',
+      'void apiClient',
+      'void axiosInstance',
+      '',
+    ].join('\n'),
+  )
+
+  execFileSync(join(workspaceRoot, 'node_modules', '.bin', 'vue-tsc'), ['--project', join(smokeTestRoot, 'tsconfig.json')], {
+    cwd: workspaceRoot,
+    stdio: 'pipe',
+  })
+
+  console.log('Package type verification passed.')
+} finally {
+  rmSync(smokeTestRoot, { recursive: true, force: true })
+
+  if (tarballPath) {
+    rmSync(tarballPath, { force: true })
+  }
+}

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from 'node:url'
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import { resolve } from "path"
 import vue from '@vitejs/plugin-vue'
@@ -10,6 +10,41 @@ import tidewave from 'tidewave/vite-plugin'
 const bffOpenApiSource = resolve(__dirname, '../bff/bff_app/openapi/openapi.yaml')
 const bffOpenApiDistDir = resolve(__dirname, 'dist/bff')
 const bffOpenApiDistFile = resolve(bffOpenApiDistDir, 'openapi.yaml')
+const distDir = resolve(__dirname, 'dist')
+
+const libraryEntryPoints = {
+  lib: resolve(__dirname, 'src/lib.ts'),
+  router: resolve(__dirname, 'src/router/index.ts'),
+  containers: resolve(__dirname, 'src/containers/index.ts'),
+  network: resolve(__dirname, 'src/network/index.ts'),
+}
+
+const declarationEntryPoints = {
+  lib: [
+    "export * from './src/lib';",
+    "export { default } from './src/lib';",
+  ].join('\n'),
+  router: "export * from './src/router/index';",
+  containers: "export * from './src/containers/index';",
+  network: [
+    "export { default as axiosInstance } from './src/network/axios';",
+    "export { default as apiClient } from './src/network/apiClient';",
+    "export { default as typedApiClient } from './src/network/typedApiClient';",
+  ].join('\n'),
+}
+
+function writeDeclarationEntryPoints() {
+  return {
+    name: 'write-declaration-entry-points',
+    closeBundle() {
+      mkdirSync(distDir, { recursive: true })
+
+      for (const [entryName, declarationContent] of Object.entries(declarationEntryPoints)) {
+        writeFileSync(resolve(distDir, `${entryName}.d.ts`), `${declarationContent}\n`)
+      }
+    },
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -30,9 +65,18 @@ export default defineConfig({
     tailwindcss(),
     dts({
       include: ['src'],
+      exclude: [
+        'src/**/*.mdx',
+        'src/**/*.stories.ts',
+        'src/**/*.spec.ts',
+        'src/**/*.test.ts',
+        'src/**/__tests__/**',
+        'src/demo/**',
+      ],
       tsconfigPath: './tsconfig.app.json',
-      rollupTypes: true
+      rollupTypes: false,
     }),
+    writeDeclarationEntryPoints(),
   ],
   resolve: {
     alias: {
@@ -43,12 +87,7 @@ export default defineConfig({
     outDir: 'dist',
     lib: {
       // src/lib.ts is where we have exported the component(s)
-      entry: {
-        lib: resolve(__dirname, "src/lib.ts"),
-        router: resolve(__dirname, "src/router/index.ts"),
-        containers: resolve(__dirname, "src/containers/index.ts"),
-        network: resolve(__dirname, "src/network/index.ts")
-      },
+      entry: libraryEntryPoints,
       name: "wefa",
       // the name of the output files when the build is run
       //fileName: "wefa",


### PR DESCRIPTION
Fix a misconfiguration of exports that led to bugs using the network layer

- Introduced `verify-package-types.mjs` to validate subpath exports and declarations.
- Enhanced `package.json` exports with type paths for improved type safety.
- Updated `vite.config.ts` to generate declaration entrypoints.
- Integrated package-type verification into CI workflows and contributor documentation.