### PR TITLE
Add `locales` subpath export and declaration generation

### DIFF
--- a/vue/package.json
+++ b/vue/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/network.js",
       "require": "./dist/network.cjs"
     },
+    "./locales": {
+      "types": "./dist/locales.d.ts",
+      "import": "./dist/locales.js",
+      "require": "./dist/locales.cjs"
+    },
     "./bff-openapi": "./dist/bff/openapi.yaml",
     "./types": "./dist/lib.d.ts",
     "./style": "./src/assets/main.css"

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -17,6 +17,7 @@ const libraryEntryPoints = {
   router: resolve(__dirname, 'src/router/index.ts'),
   containers: resolve(__dirname, 'src/containers/index.ts'),
   network: resolve(__dirname, 'src/network/index.ts'),
+  locales: resolve(__dirname, 'src/locales/index.ts'),
 }
 
 const declarationEntryPoints = {
@@ -31,6 +32,7 @@ const declarationEntryPoints = {
     "export { default as apiClient } from './src/network/apiClient';",
     "export { default as typedApiClient } from './src/network/typedApiClient';",
   ].join('\n'),
+  locales: "export * from './src/locales/index';",
 }
 
 function writeDeclarationEntryPoints() {


### PR DESCRIPTION
- Added `locales` entry to `package.json` exports for improved module clarity.
- Updated `vite.config.ts` to include `locales` in path resolution and declaration entrypoints.